### PR TITLE
Bump mesos-framework 0.2.9 to fix mesos 1.x compatability, make docker image configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var ContainerInfo = new Mesos.ContainerInfo(
     null, // Volumes
     null, // Hostname
     new Mesos.ContainerInfo.DockerInfo(
-        "mesoshq/flink:1.1.2", // Image
+        process.env.FLINK_DOCKER_IMAGE || "mesoshq/flink:1.1.3", // Image
         Mesos.ContainerInfo.DockerInfo.Network.HOST, // Network
         null,  // PortMappings
         false, // Privileged

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "express": "^4.14.0",
     "lodash": "^4.14.0",
-    "mesos-framework": "^0.2.8",
+    "mesos-framework": "^0.2.9",
     "require-environment-variables": "^1.1.2"
   }
 }


### PR DESCRIPTION
version bump should be straightforward.

Not sure if there's a better way to add a parameter than in df1f9f5, but this worked for me. Suggestions for a better name than INNER_DOCKER_IMAGE also welcome.

Flink 1.2 is supposed to have "native" support for mesos, but until that's released, this framework seems to work with this fix and https://github.com/mesoshq/flink/pull/1